### PR TITLE
Restore original recycle prices for non-producible animals

### DIFF
--- a/src/ra2cd.mix/rulescd.ini
+++ b/src/ra2cd.mix/rulescd.ini
@@ -51,18 +51,6 @@ Soylent=500
 [CLEG]
 Soylent=750
 
-[COW]
-Soylent=200
-
-[ALL]
-Soylent=200
-
-[POLARB]
-Soylent=200
-
-[JOSH]
-Soylent=200
-
 [SPY]
 Soylent=500
 


### PR DESCRIPTION
## Summary
- remove `Soylent=200` overrides for `[COW]`, `[ALL]`, `[POLARB]`, and `[JOSH]` from `src/ra2cd.mix/rulescd.ini`
- keep anti-exploit soylent overrides for producible units unchanged
- align mod-sdk defaults with core behavior introduced for issue #36

Related: chronodivide/chronodivide-issue-tracker#36